### PR TITLE
Tests for dictionaries that are not fields

### DIFF
--- a/src/field_types.py
+++ b/src/field_types.py
@@ -24,9 +24,9 @@ def get_field_type(pdf_field):
 	button group.
 
 	Args:
-		pdf_field (dict): a dictionary that represents a field of a PDF file.
-			This argument can be a value of the dictionary returned by
-			PdfFileReader's method getFields.
+		pdf_field (PyPDF2.generic.Field): a dictionary that represents a field
+			of a PDF file. This argument can be a value of the dictionary
+			returned by PdfFileReader's method getFields.
 
 	Returns:
 		PdfFieldType: the type of pdf_field or None if no type is determined

--- a/src/field_types.py
+++ b/src/field_types.py
@@ -12,6 +12,7 @@ class PdfFieldType(Enum):
 	"""
 	This enumeration represents the field types that a PDF file can contain.
 	"""
+	NONE = -1
 	ACTION_BTN = 0
 	CHECKBOX = 1
 	RADIO_BTN_GROUP = 2
@@ -29,7 +30,8 @@ def get_field_type(pdf_field):
 			returned by PdfFileReader's method getFields.
 
 	Returns:
-		PdfFieldType: the type of pdf_field or None if no type is determined
+		PdfFieldType: the type of pdf_field. PdfFieldType.NONE indicates that
+			no type was determined
 	"""
 	type_val = pdf_field.get(_FIELD_TYPE)
 
@@ -47,4 +49,4 @@ def get_field_type(pdf_field):
 			return PdfFieldType.CHECKBOX
 
 	else:
-		return None
+		return PdfFieldType.NONE

--- a/tests/field_type_tests.py
+++ b/tests/field_type_tests.py
@@ -8,7 +8,7 @@ from ..src import\
 	get_field_type
 
 
-_FIELDS_EMPTY_PATH = Path(__file__).parent/"fields_empty.pdf"
+_FIELDS_EMPTY_PATH = (Path(__file__).parent/"fields_empty.pdf").resolve()
 _MODE_RB = "rb"
 
 

--- a/tests/field_type_tests.py
+++ b/tests/field_type_tests.py
@@ -23,12 +23,12 @@ def field_type_test(field_name, expected_type):
 
 def test_inexistent_field_type():
 	a_dict = {"/FT": "aucun"}
-	assert get_field_type(a_dict) is None
+	assert get_field_type(a_dict) == PdfFieldType.NONE
 
 
 def test_no_field_type_key():
 	a_dict = {"x": "y"}
-	assert get_field_type(a_dict) is None
+	assert get_field_type(a_dict) == PdfFieldType.NONE
 
 
 def test_field_type_action_btn():

--- a/tests/field_type_tests.py
+++ b/tests/field_type_tests.py
@@ -21,6 +21,16 @@ def field_type_test(field_name, expected_type):
 	assert get_field_type(tested_field) == expected_type
 
 
+def test_inexistent_field_type():
+	a_dict = {"/FT": "aucun"}
+	assert get_field_type(a_dict) is None
+
+
+def test_no_field_type_key():
+	a_dict = {"x": "y"}
+	assert get_field_type(a_dict) is None
+
+
 def test_field_type_action_btn():
 	field_type_test("Initialisation", PdfFieldType.ACTION_BTN)
 	field_type_test("Valider-BAS", PdfFieldType.ACTION_BTN)


### PR DESCRIPTION
* The return value of function get_field_type is tested when it does not determined a field type.
* Its docstring prescribes type PyPDF2.generic.Field rather than dict for argument pdf_field.
* Member NONE was added to enumeration PdfFieldType.