### PR TITLE
Automated tests and demo for pair_fields_name_and_val

### DIFF
--- a/PyPDF2_Fields/__init__.py
+++ b/PyPDF2_Fields/__init__.py
@@ -4,7 +4,7 @@ from .field_types import\
 
 from .pypdf2_fields import\
 	make_writer_from_reader,\
-	pdf_field_name_val_dict,\
+	pair_fields_name_and_val,\
 	set_need_appearances,\
 	update_page_fields
 

--- a/PyPDF2_Fields/pypdf2_fields.py
+++ b/PyPDF2_Fields/pypdf2_fields.py
@@ -63,7 +63,7 @@ def make_writer_from_reader(pdf_reader, editable):
 	return pdf_writer
 
 
-def pdf_field_name_val_dict(pdf_fields, filter_none):
+def pair_fields_name_and_val(pdf_fields, filter_none):
 	"""
 	Creates a dictionary that maps the name of a PDF file's fields to their
 	value.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Crée un objet `PdfFileWriter` dont le contenu est identique à celui de l’obj
 `PdfFileReader` donné. Selon le choix de l’appelant, les champs du fichier
 produit par cet écriveur seront modifiables ou non.
 
-* **`pdf_field_name_val_dict`**
+* **`pair_fields_name_and_val`**
 
 Constitue un dictionnaire associant le nom des champs à leur valeur.
 
@@ -68,7 +68,7 @@ Creates a `PdfFileWriter` object whose content is identical to that of the
 given `PdfFileReader` object. Depending on the caller’s choice, the fields of
 the file produced by that writer will be editable or not.
 
-* **`pdf_field_name_val_dict`**
+* **`pair_fields_name_and_val`**
 
 Creates a dictionary that maps the fields’ name to their value.
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Définit la valeur des champs de texte, des boîtes à cocher et des groupes de
 boutons radio. Cette fonction utilise des instances de la classe
 `RadioBtnGroup`, aussi incluse dans cette bibliothèque.
 
-Voyez l'exemple d'utilisation `demo_update_fields.py` dans le dépôt de code
-source.
+Voyez les exemples d'utilisation `demo_field_names_vals.py` et
+`demo_update_fields.py` dans le dépôt de code source.
 
 ## English
 
@@ -83,4 +83,5 @@ Sets the value of text fields, checkboxes and radio button groups. This
 function uses instances of class `RadioBtnGroup`, which is also included in
 this library.
 
-See usage example `demo_update_fields.py` in the source code repository.
+See usage examples `demo_field_names_vals.py` and `demo_update_fields.py` in
+the source code repository.

--- a/demo_field_names_vals.py
+++ b/demo_field_names_vals.py
@@ -4,6 +4,7 @@ prints their name-value pairs in the console.
 """
 
 
+from argparse import ArgumentParser
 from pathlib import Path
 from PyPDF2 import PdfFileReader
 from sys import argv
@@ -11,13 +12,23 @@ from sys import argv
 from PyPDF2_Fields import pdf_field_name_val_dict
 
 
-pdf_file_path = Path(argv[1])
+parser = ArgumentParser(description=__doc__)
+
+parser.add_argument("-f", "--file", type=Path,
+	help="the path to the file whose fields will be printed")
+
+parser.add_argument("-e", "--empty", action="store_true",
+	help="print the empty fields.")
+
+args = parser.parse_args()
+pdf_file_path = args.file
+filter_none = not args.empty
 
 reader = PdfFileReader(pdf_file_path.open(mode="rb"), strict=False)
 
 fields = reader.getFields()
 
-field_names_vals = pdf_field_name_val_dict(fields, False)
+field_names_vals = pdf_field_name_val_dict(fields, filter_none)
 
 for name, value in field_names_vals.items():
 	print(f"{name}: {value}")

--- a/demo_field_names_vals.py
+++ b/demo_field_names_vals.py
@@ -11,7 +11,7 @@ from PyPDF2 import PdfFileReader
 from PyPDF2_Fields import\
 	PdfFieldType,\
 	get_field_type,\
-	pdf_field_name_val_dict
+	pair_fields_name_and_val
 
 
 def field_type_to_str(field_type):
@@ -47,7 +47,7 @@ reader = PdfFileReader(pdf_file_path.open(mode="rb"), strict=False)
 
 fields = reader.getFields()
 
-field_names_vals = pdf_field_name_val_dict(fields, filter_none)
+field_names_vals = pair_fields_name_and_val(fields, filter_none)
 
 for name, value in field_names_vals.items():
 	field = fields[name]

--- a/demo_field_names_vals.py
+++ b/demo_field_names_vals.py
@@ -1,0 +1,23 @@
+"""
+This demo of library PyPDF2_Fields extracts data from a PDF file's fields and
+prints their name-value pairs in the console.
+"""
+
+
+from pathlib import Path
+from PyPDF2 import PdfFileReader
+from sys import argv
+
+from PyPDF2_Fields import pdf_field_name_val_dict
+
+
+pdf_file_path = Path(argv[1])
+
+reader = PdfFileReader(pdf_file_path.open(mode="rb"), strict=False)
+
+fields = reader.getFields()
+
+field_names_vals = pdf_field_name_val_dict(fields, False)
+
+for name, value in field_names_vals.items():
+	print(f"{name}: {value}")

--- a/demo_field_names_vals.py
+++ b/demo_field_names_vals.py
@@ -1,15 +1,34 @@
 """
-This demo of library PyPDF2_Fields extracts data from a PDF file's fields and
-prints their name-value pairs in the console.
+This demo of library PyPDF2_Fields prints the name, type and value of a PDF
+file's fields in the console.
 """
 
 
 from argparse import ArgumentParser
 from pathlib import Path
 from PyPDF2 import PdfFileReader
-from sys import argv
 
-from PyPDF2_Fields import pdf_field_name_val_dict
+from PyPDF2_Fields import\
+	PdfFieldType,\
+	get_field_type,\
+	pdf_field_name_val_dict
+
+
+def field_type_to_str(field_type):
+	if field_type == PdfFieldType.NONE:
+		return "none"
+
+	elif field_type == PdfFieldType.ACTION_BTN:
+		return "action btn"
+
+	elif field_type == PdfFieldType.CHECKBOX:
+		return "checkbox"
+
+	elif field_type == PdfFieldType.RADIO_BTN_GROUP:
+		return "radio btn group"
+
+	elif field_type == PdfFieldType.TEXT_FIELD:
+		return "text"
 
 
 parser = ArgumentParser(description=__doc__)
@@ -31,4 +50,7 @@ fields = reader.getFields()
 field_names_vals = pdf_field_name_val_dict(fields, filter_none)
 
 for name, value in field_names_vals.items():
-	print(f"{name}: {value}")
+	field = fields[name]
+	field_type = get_field_type(field)
+	type_str = field_type_to_str(field_type)
+	print(f"{name} ({type_str}): {value}")

--- a/demo_update_fields.py
+++ b/demo_update_fields.py
@@ -42,7 +42,7 @@ field_content = {
 	"Group4": 0,
 	# "Yes" in French. Makes the box checked.
 	"Boite1": "/Oui",
-	# "No" in French. Makes the box unchecked.
+	# "No" in French. Makes the box unchecked. Optional.
 	"Boite3": "/Non",
 	"Date": "2022-01-21",
 	"Province": "Québec"

--- a/tests/name_val_dict_tests.py
+++ b/tests/name_val_dict_tests.py
@@ -39,7 +39,9 @@ _EXPECTED_VALUES = {
 }
 
 
-def _field_content_test(fields, ignore_none):
+def _field_content_test(test_dir_path, ignore_none):
+	reader = _make_test_file_and_reader(test_dir_path)
+	fields = reader.getFields()
 	field_names_vals = pdf_field_name_val_dict(fields, ignore_none)
 
 	expected_names = list(_EXPECTED_VALUES.keys())
@@ -69,7 +71,15 @@ def _field_content_test(fields, ignore_none):
 			assert field_value is None
 
 
-def _make_test_file(tmp_dir):
+def _make_reader_for_template():
+	return PdfFileReader(_FIELDS_EMPTY_PATH.open(mode=_MODE_RB), strict=False)
+
+
+def _make_reader_for_test_file(test_file_path):
+	return PdfFileReader(test_file_path.open(mode=_MODE_RB), strict=False)
+
+
+def _make_test_file_and_reader(test_dir_path):
 	template_reader = _make_reader_for_template()
 	writer = make_writer_from_reader(template_reader, False)
 
@@ -99,27 +109,15 @@ def _make_test_file(tmp_dir):
 
 	set_need_appearances(writer, True)
 
-	test_file_path = tmp_dir/_TEST_FILE_NAME
+	test_file_path = test_dir_path/_TEST_FILE_NAME
 	writer.write(test_file_path.open(mode=_MODE_WB))
 
 	return _make_reader_for_test_file(test_file_path)
 
 
-def _make_reader_for_template():
-	return PdfFileReader(_FIELDS_EMPTY_PATH.open(mode=_MODE_RB), strict=False)
-
-
-def _make_reader_for_test_file(test_file_path):
-	return PdfFileReader(test_file_path.open(mode=_MODE_RB), strict=False)
-
-
 def test_name_val_dict_dont_filter_none(tmp_path):
-	reader = _make_test_file(tmp_path)
-	fields = reader.getFields()
-	_field_content_test(fields, False)
+	_field_content_test(tmp_path, False)
 
 
 def test_name_val_dict_filter_none(tmp_path):
-	reader = _make_test_file(tmp_path)
-	fields = reader.getFields()
-	_field_content_test(fields, True)
+	_field_content_test(tmp_path, True)

--- a/tests/name_val_dict_tests.py
+++ b/tests/name_val_dict_tests.py
@@ -17,18 +17,22 @@ _TEST_FILE_PATH = Path(__file__).parent.resolve()/"name_val_test_file.pdf"
 _MODE_RB = "rb"
 _MODE_WB = "wb"
 
+# The value of these fields is calculated automatically
+# if and only if the test file is filled manually.
+# "Réclamation$", "TotalMontant", "TotalccMontant$"
+
 _EXPECTED_VALUES = {
 	"Détails4": "Dépense 4",
-	"Réclamation$": 7,
+	"Réclamation$": 0,
 	"Montant$7": 7,
 	"Group1": "/Choix1",
-	"Group4": "/Ch#E8que",
+	#"Group4": "/Ch#E8que",
 	"Boite1": "/Oui",
 	"Boite3": "/Non",
 	"Date": "2022-02-03",
 	"Province": "Québec",
 	"NomSupHiérarchique": "Guyllaume Rousseau",
-	"TotalMontant": 7,
+	"TotalMontant": 0,
 	"TotalccMontant$": 0,
 	"libelSiEtudiant":\
 		"Inscrire adresse et courriel si le demandeur est un(e) étudiant(e) :"
@@ -39,6 +43,40 @@ def _delete_test_file():
 	_TEST_FILE_PATH.unlink()
 
 
+def _field_content_test(ignore_none):
+	_make_test_file()
+	reader = _make_reader_for_test_file()
+	fields = reader.getFields()
+
+	field_names_vals = pdf_field_name_val_dict(fields, ignore_none)
+
+	expected_names = list(_EXPECTED_VALUES.keys())
+	expected_names.sort()
+
+	actual_names = list(field_names_vals.keys())
+	actual_names.sort()
+
+	if ignore_none:
+		assert actual_names == expected_names
+
+	else:
+		for name in expected_names:
+			assert name in actual_names
+
+	for field_value in expected_names:
+		actual_value = field_names_vals.get(field_value)
+		expected_value = _EXPECTED_VALUES.get(field_value)
+		assert str(actual_value) == str(expected_value)
+		del field_names_vals[field_value]
+
+	if ignore_none:
+		assert len(field_names_vals) == 0
+
+	else:
+		for field_value in field_names_vals.values():
+			assert field_value is None
+
+
 def _make_test_file():
 	reader = _make_reader_for_template()
 	writer = make_writer_from_reader(reader, False)
@@ -47,7 +85,7 @@ def _make_test_file():
 		"Détails4": "Dépense 4",
 		"Montant$7": 7,
 		"Group1": 0,
-		"Group4": 1,
+		#"Group4": 1,
 		# "Yes" in French. Makes the box checked.
 		"Boite1": "/Oui",
 		# "No" in French. Makes the box unchecked. Optional.
@@ -79,27 +117,12 @@ def _make_reader_for_test_file():
 	return PdfFileReader(_TEST_FILE_PATH.open(mode=_MODE_RB), strict=False)
 
 
+def test_name_val_dict_dont_filter_none():
+	_field_content_test(False)
+
+
 def test_name_val_dict_filter_none():
-	_make_test_file()
-	reader = _make_reader_for_test_file()
-	fields = reader.getFields()
-	del reader
-	field_names_vals = pdf_field_name_val_dict(fields, True)
+	_field_content_test(True)
 
-	expected_names = list(_EXPECTED_VALUES.keys())
-	expected_names.sort()
 
-	actual_names = list(field_names_vals.keys())
-	actual_names.sort()
-
-	try:
-		assert actual_names == expected_names
-
-		for field_name in expected_names:
-			actual_value = field_names_vals.get(field_name)
-			expected_value = _EXPECTED_VALUES.get(field_name)
-			assert actual_value == expected_value
-			del field_names_vals[field_name]
-
-	finally:
-		_delete_test_file()
+#_delete_test_file()

--- a/tests/name_val_dict_tests.py
+++ b/tests/name_val_dict_tests.py
@@ -17,6 +17,9 @@ _TEST_FILE_NAME = "name_val_test_file.pdf"
 _MODE_RB = "rb"
 _MODE_WB = "wb"
 
+# Group4 works fine in the demo, but it contains a strange binary
+# string here. It is ignored in the tests for this reason.
+
 # The value of these fields is calculated automatically
 # if and only if the test file is filled manually.
 # "Réclamation$", "TotalMontant", "TotalccMontant$"

--- a/tests/name_val_dict_tests.py
+++ b/tests/name_val_dict_tests.py
@@ -1,0 +1,105 @@
+import pytest
+
+from pathlib import Path
+from PyPDF2 import PdfFileReader
+
+from ..PyPDF2_Fields import\
+	make_writer_from_reader,\
+	pdf_field_name_val_dict,\
+	RadioBtnGroup,\
+	set_need_appearances,\
+	update_page_fields
+
+
+_FIELDS_EMPTY_PATH = Path(__file__).parent.resolve()/"fields_empty.pdf"
+_TEST_FILE_PATH = Path(__file__).parent.resolve()/"name_val_test_file.pdf"
+
+_MODE_RB = "rb"
+_MODE_WB = "wb"
+
+_EXPECTED_VALUES = {
+	"Détails4": "Dépense 4",
+	"Réclamation$": 7,
+	"Montant$7": 7,
+	"Group1": "/Choix1",
+	"Group4": "/Ch#E8que",
+	"Boite1": "/Oui",
+	"Boite3": "/Non",
+	"Date": "2022-02-03",
+	"Province": "Québec",
+	"NomSupHiérarchique": "Guyllaume Rousseau",
+	"TotalMontant": 7,
+	"TotalccMontant$": 0,
+	"libelSiEtudiant":\
+		"Inscrire adresse et courriel si le demandeur est un(e) étudiant(e) :"
+}
+
+
+def _delete_test_file():
+	_TEST_FILE_PATH.unlink()
+
+
+def _make_test_file():
+	reader = _make_reader_for_template()
+	writer = make_writer_from_reader(reader, False)
+
+	field_content = {
+		"Détails4": "Dépense 4",
+		"Montant$7": 7,
+		"Group1": 0,
+		"Group4": 1,
+		# "Yes" in French. Makes the box checked.
+		"Boite1": "/Oui",
+		# "No" in French. Makes the box unchecked. Optional.
+		"Boite3": "/Non",
+		"Date": "2022-02-03",
+		"Province": "Québec",
+		"NomSupHiérarchique": "Guyllaume Rousseau"
+	}
+
+	radio_btn_group1 = RadioBtnGroup(
+		"Group1", "/Choix1", "/Choix2")
+	radio_btn_group2 = RadioBtnGroup(
+		"Group2", "/Choix1", "/Choix2")
+	radio_btn_group4 = RadioBtnGroup(
+		"Group4", "/Dépôt", "/Chèque")
+
+	update_page_fields(writer.getPage(0), field_content,
+		radio_btn_group1, radio_btn_group2, radio_btn_group4)
+
+	set_need_appearances(writer, True)
+	writer.write(_TEST_FILE_PATH.open(mode=_MODE_WB))
+
+
+def _make_reader_for_template():
+	return PdfFileReader(_FIELDS_EMPTY_PATH.open(mode=_MODE_RB), strict=False)
+
+
+def _make_reader_for_test_file():
+	return PdfFileReader(_TEST_FILE_PATH.open(mode=_MODE_RB), strict=False)
+
+
+def test_name_val_dict_filter_none():
+	_make_test_file()
+	reader = _make_reader_for_test_file()
+	fields = reader.getFields()
+	del reader
+	field_names_vals = pdf_field_name_val_dict(fields, True)
+
+	expected_names = list(_EXPECTED_VALUES.keys())
+	expected_names.sort()
+
+	actual_names = list(field_names_vals.keys())
+	actual_names.sort()
+
+	try:
+		assert actual_names == expected_names
+
+		for field_name in expected_names:
+			actual_value = field_names_vals.get(field_name)
+			expected_value = _EXPECTED_VALUES.get(field_name)
+			assert actual_value == expected_value
+			del field_names_vals[field_name]
+
+	finally:
+		_delete_test_file()

--- a/tests/name_val_dict_tests.py
+++ b/tests/name_val_dict_tests.py
@@ -60,11 +60,11 @@ def _field_content_test(test_dir_path, ignore_none):
 		for name in expected_names:
 			assert name in actual_names
 
-	for field_value in expected_names:
-		actual_value = field_names_vals.get(field_value)
-		expected_value = _EXPECTED_VALUES.get(field_value)
+	for field_name in expected_names:
+		actual_value = field_names_vals.get(field_name)
+		expected_value = _EXPECTED_VALUES.get(field_name)
 		assert str(actual_value) == str(expected_value)
-		del field_names_vals[field_value]
+		del field_names_vals[field_name]
 
 	if ignore_none:
 		assert len(field_names_vals) == 0

--- a/tests/name_val_dict_tests.py
+++ b/tests/name_val_dict_tests.py
@@ -17,8 +17,8 @@ _TEST_FILE_NAME = "name_val_test_file.pdf"
 _MODE_RB = "rb"
 _MODE_WB = "wb"
 
-# Group4 works fine in the demo, but it contains a strange binary
-# string here. It is ignored in the tests for this reason.
+# Group4 does not cause problems in the demo, but here, it contains a
+# strange binary string. It is ignored in the tests for this reason.
 
 # The value of these fields is calculated automatically
 # if and only if the test file is filled manually.

--- a/tests/name_val_dict_tests.py
+++ b/tests/name_val_dict_tests.py
@@ -5,7 +5,7 @@ from PyPDF2 import PdfFileReader
 
 from ..PyPDF2_Fields import\
 	make_writer_from_reader,\
-	pdf_field_name_val_dict,\
+	pair_fields_name_and_val,\
 	RadioBtnGroup,\
 	set_need_appearances,\
 	update_page_fields
@@ -45,7 +45,7 @@ _EXPECTED_VALUES = {
 def _field_content_test(test_dir_path, ignore_none):
 	reader = _make_test_file_and_reader(test_dir_path)
 	fields = reader.getFields()
-	field_names_vals = pdf_field_name_val_dict(fields, ignore_none)
+	field_names_vals = pair_fields_name_and_val(fields, ignore_none)
 
 	expected_names = list(_EXPECTED_VALUES.keys())
 	expected_names.sort()

--- a/tests/run_all_tests.py
+++ b/tests/run_all_tests.py
@@ -6,3 +6,4 @@ local_dir = Path(__file__).parent.resolve()
 
 system(f"pytest {local_dir/'field_type_tests.py'}")
 system(f"pytest {local_dir/'radio_btn_group_tests.py'}")
+system(f"pytest {local_dir/'name_val_dict_tests.py'}")


### PR DESCRIPTION
* That function had only been tested manually during development.
* Originally, its name was pdf_field_name_val_dict.
* Field Group4 does not cause problems in the demo, but it contains a strange binary string in the tests. It is ignored in the automated tests for this reason. 