### PR TITLE
Metadata for conda-forge

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -37,7 +37,6 @@ about:
     Library PyPDF2_Fields is a complement to PyPDF2.
     It helps reading and setting a PDF file's fields,
     knowing their type and controlling their editability.
-  description: "See the README in the GitHub repository (home)."
   license: MIT
   license_file: LICENSE
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "PyPDF2_Fields" %}
-{% set version = "1.0.0" %}
+{% set version = "1.0.1" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/PyPDF2_Fields-{{ version }}.tar.gz
-  sha256: 017f0efcf9625b1e47d000e1c27442358169e98362a55d090280d201f0aaedc4
+  sha256: 22f03264d022d8e8e89881ed745047797ae8bf697e69705ffc39f072691710e1
 
 build:
   number: 0
@@ -34,8 +34,9 @@ test:
 about:
   home: https://github.com/GRV96/PyPDF2_Fields
   summary: >-
-    Library PyPDF2_Fields is a complement to PyPDF2. It helps
-    using a PDF file's fields by facilitating several tasks.
+    Library PyPDF2_Fields is a complement to PyPDF2.
+    It helps reading and setting a PDF file's fields,
+    knowing their type and controlling their editability.
   description: "See the README in the GitHub repository (home)."
   license: MIT
   license_file: LICENSE

--- a/meta.yaml
+++ b/meta.yaml
@@ -18,10 +18,10 @@ build:
 requirements:
   host:
     - pip
-    - python
+    - python >=3.6
   run:
     - pypdf2 ==1.26.0
-    - python
+    - python >=3.6
 
 test:
   imports:
@@ -33,7 +33,9 @@ test:
 
 about:
   home: https://github.com/GRV96/PyPDF2_Fields
-  summary: "Library PyPDF2_Fields is a complement to PyPDF2. It helps using a PDF file's fields by facilitating several tasks."
+  summary: >-
+    Library PyPDF2_Fields is a complement to PyPDF2. It helps
+    using a PDF file's fields by facilitating several tasks.
   description: "See the README in the GitHub repository (home)."
   license: MIT
   license_file: LICENSE

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "PyPDF2_Fields" %}
+{% set version = "1.0.0" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/PyPDF2_Fields-{{ version }}.tar.gz
+  sha256: 017f0efcf9625b1e47d000e1c27442358169e98362a55d090280d201f0aaedc4
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - pypdf2 ==1.26.0
+    - python
+
+test:
+  imports:
+    - PyPDF2_Fields
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/GRV96/PyPDF2_Fields
+  summary: "Library PyPDF2_Fields is a complement to PyPDF2. It helps using a PDF file's fields by facilitating several tasks."
+  description: "See the README in the GitHub repository (home)."
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - GRV96

--- a/setup.py
+++ b/setup.py
@@ -29,13 +29,12 @@ def _make_requirement_list():
 	with open(_REQUIREMENT_FILE, _MODE_R, encoding=_ENCODING_UTF8) as req_file:
 		req_str = req_file.read()
 
-	requirements = req_str.split("\n")
+	raw_requirements = req_str.split("\n")
 
-	i = 0
-	while i < len(requirements):
-		if len(requirements[i]) == 0:
-			del requirements[i]
-		i += 1
+	requirements = list()
+	for requirement in raw_requirements:
+		if len(requirement) > 0:
+			requirements.append(requirement)
 
 	return requirements
 

--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,9 @@ def _make_requirement_list():
 if __name__ == "__main__":
 	setuptools.setup(
 		name = "PyPDF2_Fields",
-		version = "1.0.0",
+		version = "1.0.1",
 		author = "Guyllaume Rousseau",
-		description = "Library PyPDF2_Fields is a complement to PyPDF2. It helps using a PDF file’s fields by facilitating several tasks.",
+		description = "Library PyPDF2_Fields is a complement to PyPDF2. It helps reading and setting a PDF file’s fields, knowing their type and controlling their editability.",
 		long_description = _make_long_description(),
 		long_description_content_type = "text/markdown",
 		url = "https://github.com/GRV96/PyPDF2_Fields",


### PR DESCRIPTION
File `meta.yaml` is the recipe required to publish this library on channel `conda-forge`. A fault in `setup.py` was fixed. The version was inremented from 1.0.0 to 1.0.1 because the library's description was changed.